### PR TITLE
Don't require pr-approval/authenticate for PRB

### DIFF
--- a/packages/pkl.impl.circleci/PklCI.pkl
+++ b/packages/pkl.impl.circleci/PklCI.pkl
@@ -16,10 +16,6 @@
 /// CI job template specifically for Pkl projects.
 module pkl.impl.circleci.PklCI
 
-// TODO: Undo this hack to break the cycle; pkl-pantry depends on pkl-project-commons and vice-versa.
-// Copied in `Config.pkl` locally, so that `pkl-project-commons` builds green and publishes.
-// Releasing `pkl-project-commons` first allows `pkl-pantry` to be released dependent on it. After `pkl-pantry`
-// is public, delete `Config.pkl` from this repository and use the `package://` import below.
 import "@circleci/Config.pkl"
 
 /// A map of user-selected names to either: orb references (strings) or orb definitions (maps).
@@ -214,13 +210,13 @@ local requireApproval = (it: String|Mapping<String, Config.WorkflowJob>) ->
   if (it is String)
     new Mapping<String, Config.WorkflowJob> {
       [it] {
-        requires { "hold"; "pr-approval/authenticate" }
+        requires { "hold" }
       }
     }
   else
     (it) {
       [it.keys.first] {
-        requires { "hold"; "pr-approval/authenticate" }
+        requires { "hold" }
       }
     }
 

--- a/packages/pkl.impl.circleci/PklProject
+++ b/packages/pkl.impl.circleci/PklProject
@@ -16,7 +16,7 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.1"
+  version = "1.0.2"
 }
 
 dependencies {


### PR DESCRIPTION
It's not actually necessary to require this job for PRBs.

This will allow us to run PRB workflows if the pr-approval/authenticate job fails.