### PR TITLE
Add trigger downstream build logic

### DIFF
--- a/packages/pkl.impl.ghactions/PklCI.pkl
+++ b/packages/pkl.impl.ghactions/PklCI.pkl
@@ -24,7 +24,8 @@ import "actions/PublishUnitTestResult.pkl"
 /// The workflow that runs during pull requests.
 ///
 /// The following fields are overwritten and therefore don't need to be set:
-///   * [Workflow.on]
+///
+///   * [Workflow.On.pull_request]
 ///   * [Workflow.name]
 ///
 /// This turns into a workflow called "Pull Request".
@@ -32,8 +33,8 @@ prb: Workflow
 
 /// The workflow to run for commits that land on the main branch.
 ///
-/// The following fields are overwritten and therefore don't need to be set:
-///   * [Workflow.on]
+/// The following fields are amended with additional settings:
+///   * [Workflow.On.push]
 ///   * [Workflow.name]
 ///
 /// This turns into a workflow called "Build (main)".
@@ -41,8 +42,8 @@ main: Workflow
 
 /// The workflow to run for commits that land on all branches except for main.
 ///
-/// The following fields are overwritten and therefore don't need to be set:
-///   * [Workflow.on]
+/// The following fields are amended with additional settings:
+///   * [Workflow.On.push]
 ///   * [Workflow.name]
 ///
 /// This turns into a workflow called "Build".
@@ -50,8 +51,8 @@ build: Workflow
 
 /// The workflow that runs when tags are pushed.
 ///
-/// The following fields are overwritten and therefore don't need to be set:
-///   * [Workflow.on]
+/// The following fields are amended with additional settings:
+///   * [Workflow.On.push]
 ///   * [Workflow.name]
 ///
 /// This turns into a workflow called "Release".
@@ -61,6 +62,24 @@ release: Workflow?
 ///
 /// Turns into steps that upload and processes test results.
 testReports: TestReports
+
+/// Whether to trigger a build of the Pkl docsite or not.
+///
+/// * `"none"` - does not trigger build after the [release] workflow (default)
+/// * `"release"` - trigger build after the [release] workflow only.
+/// * `"both"` - trigger build for the [release] workflow and the [main] workflow.
+/// `both` should only be used for projects where we publish documentation
+/// for dev/snapshot builds.
+///
+/// The secret `PKL_TRIGGER_ACTION_GH_TOKEN must be available to the workflow.
+triggerDocsBuild: "none"|"release"|"both" = "none"
+
+/// Whether to trigger a build of pkl-package-docs or not.
+///
+/// * `"none"` -- does not trigger a build after the [release] workflow (default)
+/// * `"release"` -- trigger a build after the [release] workflow
+/// * `"main"` -- trigger a build after the [main] workflow
+triggerPackageDocsBuild: "none"|"main"|"release" = "none"
 
 class TestReports {
   /// Paths, directories, and globs to junit test reports, to be processed by a GitHub Actions test reporter.
@@ -72,7 +91,7 @@ class TestReports {
 
 local effectiveBuildWorkflow = (build) {
   name = "Build"
-  on = new {
+  on {
     push {
       `branches-ignore` {
         "main"
@@ -85,9 +104,9 @@ local effectiveBuildWorkflow = (build) {
   jobs = super.jobs |> withPublishTestResults |> withUploadTestResultHtml
 }
 
-local effectiveMainWorkflow = (build) {
+local effectiveMainWorkflow = (main) {
   name = "Build (main)"
-  on = new {
+  on {
     push {
       branches {
         "main"
@@ -97,7 +116,10 @@ local effectiveMainWorkflow = (build) {
       }
     }
   }
-  jobs = super.jobs |> withPublishTestResults |> withUploadTestResultHtml
+  jobs = super.jobs
+    |> withPublishTestResults
+    |> withUploadTestResultHtml
+    |> withTriggerWorkflows("main")
 }
 
 /// Can't use [withPublishTestResults] because PRs submitted from forks can't create check runs.
@@ -105,7 +127,7 @@ local effectiveMainWorkflow = (build) {
 /// published here.
 local effectivePrbWorkflow = (prb) {
   name = "Pull Request"
-  on = new {
+  on {
     pull_request {}
   }
   jobs = super.jobs |> withUploadTestResultXml |> withUploadTestResultHtml
@@ -113,7 +135,7 @@ local effectivePrbWorkflow = (prb) {
 
 local effectiveReleaseWorkflow = (release) {
   name = "Release"
-  on = new {
+  on {
     push {
       tags {
         "*"
@@ -123,7 +145,10 @@ local effectiveReleaseWorkflow = (release) {
       }
     }
   }
-  jobs = super.jobs |> withPublishTestResults |> withUploadTestResultHtml
+  jobs = super.jobs
+    |> withPublishTestResults
+    |> withUploadTestResultHtml
+    |> withTriggerWorkflows("release")
 }
 
 local testReportWorkflow: Workflow = new {
@@ -213,43 +238,47 @@ local withUploadTestResultHtml: Mixin<Workflow.Jobs> = new {
   }
 }
 
-local withPublishTestResults: Mixin<Workflow.Jobs> = (it) ->
-  let (hasMatrixBuild = it.any((_, job) -> job.strategy?.matrix != null))
-    // if there are matrix builds, we need to publish test results as an xml artifact, then publish as a separate job.
-    if (hasMatrixBuild)
-      (it) {
-        [[true]] {
-          local self = this
-          steps {
-            // matrix build; upload test results as an artifact
-            new Artifact.Upload {
-              name = "Upload Test Result XML"
-              path = testReports.junit.join("\n")
-              `if` = "!cancelled()"
-              artifactName = "\(TEST_RESULT_XML_ARTIFACT_NAME)-\(self.strategy.matrix.keys.join("-"))"
-            }
-          }
-        }
-        ["publish-test-results"] {
-          needs {
-            ...it.keys
-          }
-          `runs-on` = "ubuntu-latest"
-          permissions {
-            checks = "write"
-          }
-          steps {
-            new PublishUnitTestResult {
-              name = "Publish test results"
-              `if` = "!cancelled()"
-              with {
-                file_patterns = testReports.junit
-                comment_mode = "off"
-              }
-            }.step
-          }
-        }
+local withPublishTestResultsForMatrixBuild: Mixin<Workflow.Jobs> = (it) -> (it) {
+  [[true]] {
+    local self = this
+    steps {
+      // matrix build; upload test results as an artifact
+      new Artifact.Upload {
+        name = "Upload Test Result XML"
+        path = testReports.junit.join("\n")
+        `if` = "!cancelled()"
+        artifactName = "\(TEST_RESULT_XML_ARTIFACT_NAME)-\(self.strategy.matrix.keys.join("-"))"
       }
+    }
+  }
+  ["publish-test-results"] {
+    needs {
+      ...it.keys
+    }
+    `runs-on` = "ubuntu-latest"
+    permissions {
+      checks = "write"
+    }
+    steps {
+      new PublishUnitTestResult {
+        name = "Publish test results"
+        `if` = "!cancelled()"
+        with {
+          file_patterns = testReports.junit
+          comment_mode = "off"
+        }
+      }.step
+    }
+  }
+}
+
+local withPublishTestResults: Mixin<Workflow.Jobs> = (it) ->
+  if (testReports.junit.isEmpty)
+    it
+  else
+    // if there are matrix builds, we need to publish test results as an xml artifact, then publish as a separate job.
+    if (it.any((_, job) -> job.strategy?.matrix != null))
+      it |> withPublishTestResultsForMatrixBuild
     else
       (it) {
         [[true]] {
@@ -269,6 +298,49 @@ local withPublishTestResults: Mixin<Workflow.Jobs> = (it) ->
         }
       }
 
+local function withTriggerWorkflows(triggerType: String): Mixin<Workflow.Jobs> = (it) -> (it) {
+  when (triggerType == triggerDocsBuild || triggerType == triggerPackageDocsBuild || triggerDocsBuild == "both") {
+    ["trigger-downstream-builds"] {
+      needs {
+        ...it.keys
+      }
+      `runs-on` = "ubuntu-latest"
+      steps {
+        when (triggerType == triggerDocsBuild || triggerDocsBuild == "both") {
+          new {
+            name = "Trigger pkl-lang.org build"
+            env {
+              ["GH_TOKEN"] = "${{ secrets.PKL_TRIGGER_ACTION_GH_TOKEN }}"
+            }
+            run = #"""
+              gh workflow run \
+                --repo \#(Context.github.repositoryOwner)/pkl-lang.org \
+                --ref main \
+                --field source_run="\#(Context.github.serverUrl)/\#(Context.github.repository)/actions/runs/\#(Context.github.runId)" \
+                main.yml
+              """#
+          }
+        }
+        when (triggerType == triggerPackageDocsBuild) {
+          new {
+            name = "Trigger pkl-package-docs build"
+            env {
+              ["GH_TOKEN"] = "${{ secrets.PKL_TRIGGER_ACTION_GH_TOKEN }}"
+            }
+            run = #"""
+              gh workflow run \
+                --repo \#(Context.github.repositoryOwner)/pkl-package-docs \
+                --ref main \
+                --field source_run="\#(Context.github.serverUrl)/\#(Context.github.repository)/actions/runs/\#(Context.github.runId)" \
+                main.yml
+              """#
+          }
+        }
+      }
+    }
+  }
+}
+
 output {
   files {
     ["workflows/prb.yml"] = effectivePrbWorkflow.output
@@ -277,6 +349,8 @@ output {
     when (release != null) {
       ["workflows/release.yml"] = effectiveReleaseWorkflow.output
     }
-    ["workflows/test_report.yml"] = testReportWorkflow.output
+    when (!testReports.junit.isEmpty) {
+      ["workflows/test_report.yml"] = testReportWorkflow.output
+    }
   }
 }

--- a/packages/pkl.impl.ghactions/PklProject
+++ b/packages/pkl.impl.ghactions/PklProject
@@ -17,7 +17,7 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "0.1.0"
+  version = "0.2.0"
 }
 
 dependencies {


### PR DESCRIPTION
Also:
* don't overwrite any other `on` that is already defined
* don't create a `test_reports` workflow if no test results are defined