### PR TITLE
Enforce default permissions at the workflow level

### DIFF
--- a/packages/pkl.impl.ghactions/PklCI.pkl
+++ b/packages/pkl.impl.ghactions/PklCI.pkl
@@ -27,6 +27,7 @@ import "actions/PublishUnitTestResult.pkl"
 ///
 ///   * [Workflow.On.pull_request]
 ///   * [Workflow.name]
+///   * [Workflow.permissions]
 ///
 /// This turns into a workflow called "Pull Request".
 prb: Workflow
@@ -36,6 +37,7 @@ prb: Workflow
 /// The following fields are amended with additional settings:
 ///   * [Workflow.On.push]
 ///   * [Workflow.name]
+///   * [Workflow.permissions]
 ///
 /// This turns into a workflow called "Build (main)".
 main: Workflow
@@ -45,6 +47,7 @@ main: Workflow
 /// The following fields are amended with additional settings:
 ///   * [Workflow.On.push]
 ///   * [Workflow.name]
+///   * [Workflow.permissions]
 ///
 /// This turns into a workflow called "Build".
 build: Workflow
@@ -54,6 +57,7 @@ build: Workflow
 /// The following fields are amended with additional settings:
 ///   * [Workflow.On.push]
 ///   * [Workflow.name]
+///   * [Workflow.permissions]
 ///
 /// This turns into a workflow called "Release".
 release: Workflow?
@@ -63,6 +67,7 @@ release: Workflow?
 /// The following fields are amended with additional settings:
 ///   * [Workflow.On.push]
 ///   * [Workflow.name]
+///   * [Workflow.permissions]
 ///
 /// This turns into a workflow called "Build (release branch)".
 releaseBranch: Workflow?
@@ -106,6 +111,9 @@ class TestReports {
 
 local effectiveBuildWorkflow = (build) {
   name = "Build"
+  permissions = new {
+    contents = "read"
+  }
   on {
     push {
       `branches-ignore` {
@@ -122,6 +130,9 @@ local effectiveBuildWorkflow = (build) {
 
 local effectiveReleaseBranchWorkflow = (build) {
   name = "Build (release branch)"
+  permissions = new {
+    contents = "read"
+  }
   on {
     push {
       branches {
@@ -137,6 +148,9 @@ local effectiveReleaseBranchWorkflow = (build) {
 
 local effectiveMainWorkflow = (main) {
   name = "Build (main)"
+  permissions = new {
+    contents = "read"
+  }
   on {
     push {
       branches {
@@ -158,6 +172,9 @@ local effectiveMainWorkflow = (main) {
 /// published here.
 local effectivePrbWorkflow = (prb) {
   name = "Pull Request"
+  permissions = new {
+    contents = "read"
+  }
   on {
     pull_request {}
   }
@@ -166,6 +183,9 @@ local effectivePrbWorkflow = (prb) {
 
 local effectiveReleaseWorkflow = (release) {
   name = "Release"
+  permissions = new {
+    contents = "read"
+  }
   on {
     push {
       tags {
@@ -184,6 +204,9 @@ local effectiveReleaseWorkflow = (release) {
 
 local testReportWorkflow: Workflow = new {
   name = "PR Test Reports"
+  permissions = new {
+    contents = "read"
+  }
 
   on {
     workflow_run {

--- a/packages/pkl.impl.ghactions/PklProject
+++ b/packages/pkl.impl.ghactions/PklProject
@@ -17,7 +17,7 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "0.3.1"
+  version = "0.3.2"
 }
 
 dependencies {


### PR DESCRIPTION
Per @incertum:

> See https://github.com/swiftlang/github-workflows/issues/167 for additional context
> 
> This approach aligns with security best practices, as detailed in the following documentation:
> 
> - https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
> - https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes
> - https://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/
> 
> 
> The default GITHUB_TOKEN permissions are defined at the repository level. This PR modifies the workflow-level overrides to conform to OpenSSF best practices -> defense in depth.
> 
> Allow me to quote OpenSSF:
> https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
> 
> > The highest score is awarded when the permissions definitions in each workflow's yaml file are set as read-only at the top level and the required write permissions are declared at the run-level.”
> 
> > Remediation steps
> > - Set top-level permissions as read-all or contents: read as described in GitHub's documentation.
> > - Set any required write permissions at the job-level. Only set the permissions required for that job; do not set permissions: write-all at the job level.
> 
> 
> Compare to the LLVM project:
> 
> Top-level: contents read, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L3-L4 -> this makes it future-proof
> 
> Job-level: Allow write permissions as needed, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L53-L58
> 