### PR TITLE
Moved to automation in https://github.com/apple/pkl-project-commons/pull/17/files chore(pkl.impl.ghactions): restrict GitHub workflow permissions - future-proof

### DIFF
--- a/packages/temp.stefma.gha/tests/Workflow.pkl-expected.pcf
+++ b/packages/temp.stefma.gha/tests/Workflow.pkl-expected.pcf
@@ -5,6 +5,8 @@ examples {
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
     
     name: PrintHelloWorld
+    permissions:
+      contents: read
     'on':
       pull_request:
         types:
@@ -95,6 +97,8 @@ examples {
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
     
     name: GitHub Action Triggers
+    permissions:
+      contents: read
     'on':
       branch_protection_rule: {}
       check_run: {}
@@ -150,6 +154,8 @@ examples {
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
     
     name: Update Wiki Readme
+    permissions:
+      contents: read
     'on':
       push:
         paths:
@@ -182,6 +188,8 @@ examples {
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
     
     name: Matrix Test
+    permissions:
+      contents: read
     'on':
       push:
         branches:
@@ -218,6 +226,8 @@ examples {
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
     
     name: Reusable Workflow
+    permissions:
+      contents: read
     'on':
       push:
         branches:
@@ -246,6 +256,8 @@ examples {
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
     
     name: Check prebuild actions
+    permissions:
+      contents: read
     'on':
       push: {}
     jobs:


### PR DESCRIPTION
See https://github.com/swiftlang/github-workflows/issues/167 for additional context

This approach aligns with security best practices, as detailed in the following documentation:

- https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes
- https://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/


The default GITHUB_TOKEN permissions are defined at the repository level. This PR modifies the workflow-level overrides to conform to OpenSSF best practices -> defense in depth.

Allow me to quote OpenSSF:
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

> The highest score is awarded when the permissions definitions in each workflow's yaml file are set as read-only at the top level and the required write permissions are declared at the run-level.

> Remediation steps
> - Set top-level permissions as read-all or contents: read as described in GitHub's documentation.
> - Set any required write permissions at the job-level. Only set the permissions required for that job; do not set permissions: write-all at the job level.


Compare to the LLVM project:

Top-level: contents read, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L3-L4 -> this makes it future-proof

Job-level: Allow write permissions as needed, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L53-L58

---

See also https://github.com/apple/pkl-intellij/pull/121#pullrequestreview-3352176446
CC @HT154