### PR TITLE
Add script to merge downstream pkl.impl.ghactions bump PRs

### DIFF
--- a/scripts/approve_downstream_prs.sh
+++ b/scripts/approve_downstream_prs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script will, for each Pkl repo, approve PRs created by ./update_downstream_ci.sh for the given version.
+# This script will, for each Pkl repo, approve PRs created by ./update_downstream_ci.sh.
 #
 # Usage: ./approve_downstream_prs.sh
 
@@ -27,7 +27,7 @@ echo "Latest pkl.impl.ghactions version: $VERSION"
 find_pr_and_approve() {
   repo="$1"
   pr_number="$(gh pr list --repo "apple/$repo" --json title,number \
-    | jq --arg VERSION $VERSION \
+    | jq --arg VERSION "$VERSION" \
       '.[]
       | select(.title == "Bump pkl.impl.ghactions to version \($VERSION)")
       | .number')"
@@ -38,7 +38,7 @@ find_pr_and_approve() {
   fi
 
   existing_approvals="$(GH_PAGER='' gh pr view --repo "apple/$repo" "$pr_number" --json reviews | \
-    jq --arg MY_GIT_USER $MY_GIT_USER \
+    jq --arg MY_GIT_USER "$MY_GIT_USER" \
     '.reviews | map(select(.author.login == $MY_GIT_USER and .state == "APPROVED")) | length')"
   if [ "$existing_approvals" != "0" ]; then
     echo "✅ https://github.com/apple/$repo/pull/$pr_number already approved"
@@ -48,6 +48,7 @@ find_pr_and_approve() {
   echo "🔧 Approve https://github.com/apple/$repo/pull/$pr_number? Files changed:"
   GH_PAGER='' gh pr diff --name-only --repo "apple/$repo" "$pr_number"
   echo
+  # shellcheck disable=SC2162
   read -p "Press enter to approve or ^C to quit"
   gh pr review --repo "apple/$repo" "$pr_number" --approve
   echo ""

--- a/scripts/merge_downstream_prs.sh
+++ b/scripts/merge_downstream_prs.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This script will, for each Pkl repo, merge PRs created by ./update_downstream_ci.sh that are approved and have passing checks.
+#
+# Usage: ./merge_downstream_prs.sh
+
+set -eo pipefail
+
+MY_GIT_USER="$(gh api user --jq '.login')"
+
+if [[ -z "$MY_GIT_USER" ]]; then
+  echo "Could not determine the current user in gh. Try running \`gh auth login -s workflow\`."
+  exit 1
+fi
+
+if [[ "$(gh auth status --json hosts --jq '.hosts."github.com"[] | .scopes')" != *workflow* ]]; then
+  echo "No \`workflow\` scope found in current session. Try running \`gh auth login -s workflow\`."
+  exit 1
+fi
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+source "$SCRIPT_DIR/repos.sh"
+
+VERSION=$(
+  curl -s https://api.github.com/repos/apple/pkl-project-commons/releases \
+    | jq -r '[.[] | select(.tag_name | startswith("pkl.impl.ghactions"))] | .[0].name | split("@")[1]'
+)
+
+echo "Latest pkl.impl.ghactions version: $VERSION"
+
+find_pr_and_merge() {
+  repo="$1"
+  pr_number="$(gh pr list --repo "apple/$repo" --json title,number \
+    | jq --arg VERSION "$VERSION" \
+      '.[]
+      | select(.title == "Bump pkl.impl.ghactions to version \($VERSION)")
+      | .number')"
+
+  if [ -z "$pr_number" ]; then
+    echo "✅ No PR to approve for $repo"
+    return 0
+  fi
+
+  existing_approvals="$(GH_PAGER='' gh pr view --repo "apple/$repo" "$pr_number" --json reviews | \
+    jq '.reviews | map(select(.state == "APPROVED")) | length')"
+  if [ "$existing_approvals" = "0" ]; then
+    echo "❌ https://github.com/apple/$repo/pull/$pr_number is not approved"
+    return 0
+  fi
+
+  non_successful_status_checks="$(GH_PAGER='' gh pr view --repo "apple/$repo" "$pr_number" --json statusCheckRollup | \
+    jq --arg MY_GIT_USER "$MY_GIT_USER" \
+    '.statusCheckRollup | map(select(.status != "COMPLETED" or (.conclusion != "SUCCESS" and .conclusion != "SKIPPED"))) | length')"
+  if [ "$non_successful_status_checks" != "0" ]; then
+    echo "❌ https://github.com/apple/$repo/pull/$pr_number has failing status checks"
+    return 0
+  fi
+
+  echo "🔧 Merging https://github.com/apple/$repo/pull/$pr_number"
+  gh pr merge --repo "apple/$repo" "$pr_number" --squash --delete-branch
+}
+
+for repo in "${REPOS[@]}"; do
+  find_pr_and_merge "$repo"
+done

--- a/scripts/repos.sh
+++ b/scripts/repos.sh
@@ -1,4 +1,4 @@
-REPOS=(
+export REPOS=(
   "pkl"
   "pkl-go"
   "pkl-go-examples"


### PR DESCRIPTION
Fun fact: without the `workflow` scope in your auth session, attempting to merge a PR that modifies a workflow file fails with:
```console
$ gh pr merge --squash
X Pull request apple/pkl#1408 is not mergeable: the base branch policy prohibits the merge.
To have the pull request merged after all the requirements have been met, add the `--auto` flag.
To use administrator privileges to immediately merge the pull request, add the `--admin` flag.
```

Only when you add the `--auto` flag do you get a helpful error (even if auto-merge is not enabled on the repo):
```console
$ gh pr merge --squash --auto
GraphQL: Pull request refusing to allow an OAuth App to create or update workflow `.github/workflows/build.yml` without `workflow` scope (enablePullRequestAutoMerge)
```

Once you know what the issue is, the fix is easy: `gh auth login -s workflow`