### PR TITLE
Fix CodeQL

### DIFF
--- a/.github/PklProject.deps.json
+++ b/.github/PklProject.deps.json
@@ -10,7 +10,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.7.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.7.1",
       "path": "../packages/pkl.impl.ghactions"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
@@ -29,9 +29,9 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.3",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.4",
       "checksums": {
-        "sha256": "a8934d84ffd11992d7baf6acfd97bae31d6112fa8add5cc8b5b4a722ce5b9ffc"
+        "sha256": "c7391119f946d7761d0ca0cc358ed8fe2bdfc691411087ccac89637bd96fec4a"
       }
     }
   }

--- a/packages/pkl.impl.ghactions/PklCI.pkl
+++ b/packages/pkl.impl.ghactions/PklCI.pkl
@@ -203,14 +203,14 @@ class CodeQLScan {
 
   /// Manual build command for the project (if [buildMode] is manual).
   buildScript: String(buildMode == "manual")?
+
+  /// Custom configuration for scanning.
+  config: CodeQLConfig?
 }
 
 class CodeQL {
   /// The scans to run during analysis.
   scans: Listing<CodeQLScan>(!isEmpty, isDistinctBy((it) -> it.language))
-
-  /// Custom configuration for scanning.
-  config: CodeQLConfig?
 
   /// The triggers for this scan.
   ///
@@ -437,7 +437,15 @@ local effectiveCodeQlWorkflow: Workflow = new {
     for (scan in codeql!!.scans) {
       ["analyze-\(scan.language)"] {
         name = "Analyze (\(scan.language))"
-        `runs-on` = "ubuntu-latest"
+        when (scan.language == "swift") {
+          `if` = "github.repository_owner == 'apple'"
+          `runs-on` {
+            "self-hosted"
+            "macos"
+          }
+        } else {
+          `runs-on` = "ubuntu-latest"
+        }
         permissions {
           `security-events` = "write"
         }
@@ -447,8 +455,8 @@ local effectiveCodeQlWorkflow: Workflow = new {
             with {
               languages = scan.language
               `build-mode` = scan.buildMode
-              when (codeql!!.config != null) {
-                codeQLConfig = codeql!!.config
+              when (scan.config != null) {
+                codeQLConfig = scan.config
               }
             }
           }

--- a/packages/pkl.impl.ghactions/PklProject
+++ b/packages/pkl.impl.ghactions/PklProject
@@ -17,7 +17,7 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.7.0"
+  version = "1.7.1"
 }
 
 dependencies {
@@ -25,7 +25,7 @@ dependencies {
     uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.6.0"
   }
   ["com.github.dependabot"] {
-    uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.3"
+    uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.4"
   }
   ["deepToTyped"] {
     uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.1.1"

--- a/packages/pkl.impl.ghactions/PklProject.deps.json
+++ b/packages/pkl.impl.ghactions/PklProject.deps.json
@@ -24,9 +24,9 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.3",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.4",
       "checksums": {
-        "sha256": "a8934d84ffd11992d7baf6acfd97bae31d6112fa8add5cc8b5b4a722ce5b9ffc"
+        "sha256": "c7391119f946d7761d0ca0cc358ed8fe2bdfc691411087ccac89637bd96fec4a"
       }
     }
   }

--- a/packages/pkl.impl.ghactions/examples/codeql.pkl
+++ b/packages/pkl.impl.ghactions/examples/codeql.pkl
@@ -45,5 +45,9 @@ codeql {
       buildMode = "manual"
       buildScript = "make build"
     }
+    new {
+      language = "swift"
+      buildMode = "autobuild"
+    }
   }
 }

--- a/packages/pkl.impl.ghactions/tests/examples.pkl-expected.pcf
+++ b/packages/pkl.impl.ghactions/tests/examples.pkl-expected.pcf
@@ -416,6 +416,26 @@ examples {
           uses: github/codeql-action/analyze@abc123 # v4
           with:
             category: /language:javascript
+      analyze-swift:
+        name: Analyze (swift)
+        if: github.repository_owner == 'apple'
+        permissions:
+          security-events: write
+        runs-on:
+        - self-hosted
+        - macos
+        steps:
+        - uses: actions/checkout@abc123 # v6
+          with:
+            persist-credentials: false
+        - uses: github/codeql-action/init@abc123 # v4
+          with:
+            languages: swift
+            build-mode: autobuild
+        - name: Perform CodeQL Analysis
+          uses: github/codeql-action/analyze@abc123 # v4
+          with:
+            category: /language:swift
     
     """
   }


### PR DESCRIPTION
* Make swift scans run on macOS; this is required by CodeQL.
* Make CodeQL config per-scan (this is actually a breaking change but we don't use this option right now).
* Bump dependabot to 1.0.4