### PR TITLE
[pkl.impl.ghactions] Add verdict job to prb workflows as entrypoint for required PR checks

### DIFF
--- a/.github/PklProject.deps.json
+++ b/.github/PklProject.deps.json
@@ -3,14 +3,14 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.6.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.7.0",
       "checksums": {
-        "sha256": "10e27d63df4a4520d8a9375962406ca5ffe74f396bd3cb1c19b1f8358505010a"
+        "sha256": "e3461c3f8d00a6a657f9fa4f391afdab4a53a2e528862a4d8624e545cd3cb2b1"
       }
     },
     "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.7.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.8.0",
       "path": "../packages/pkl.impl.ghactions"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
@@ -22,9 +22,9 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.3",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.6",
       "checksums": {
-        "sha256": "521feb6f5ff12075ebad0758799fe7ec2675d231a0e0f5456694c8d4822a8171"
+        "sha256": "85ad51d257bad4729f0b9edecade48fcad6f55bacd0fa36106782475e912919a"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -29,6 +29,14 @@ jobs:
         name: test-results-xml-build-and-test
         path: build/test-results/**/*.xml
         if-no-files-found: ignore
+  verdict:
+    if: '!cancelled() && !failure()'
+    needs:
+    - check-pkl-github-actions
+    - build-and-test
+    runs-on: ubuntu-latest
+    steps:
+    - run: 'true'
   upload-event-file:
     runs-on: ubuntu-latest
     steps:

--- a/packages/build.gradle.kts
+++ b/packages/build.gradle.kts
@@ -48,7 +48,7 @@ class PklFormatterFunc : FormatterFunc, Serializable {
   }
 
   override fun apply(input: String): String {
-    return Formatter().format(input, GrammarVersion.V1)
+    return Formatter().format(input, GrammarVersion.V2)
   }
 }
 

--- a/packages/pkl.impl.ghactions/PklCI.pkl
+++ b/packages/pkl.impl.ghactions/PklCI.pkl
@@ -111,6 +111,11 @@ releaseBranch: Workflow(isValid)?
 /// Turns into steps that upload and processes test results.
 testReports: TestReports
 
+/// List of job names of [prb] that are required for the generated "verdict" job to succeed.
+///
+/// If not specified, all jobs of [prb] that have no dependent jobs will be required.
+prbRequiredJobs: Listing<String(prb.jobs.containsKey(this))>(isDistinct)?
+
 /// CodeQL security scans to run.
 ///
 /// Sets up scanning for builds on the main branch, as well as pull requests.
@@ -167,12 +172,13 @@ class TestReports {
   excludeJobs: Listing<String | Regex>
 
   function includes(jobKey: String): Boolean =
-    !excludeJobs.any((pattern) ->
-      if (pattern is Regex)
-        pattern.matchEntire(jobKey) != null
-      else
-        pattern == jobKey
-    )
+    jobKey != "verdict"
+      && !excludeJobs.any((pattern) ->
+        if (pattern is Regex)
+          pattern.matchEntire(jobKey) != null
+        else
+          pattern == jobKey
+      )
 }
 
 class CodeQLScan {
@@ -333,7 +339,7 @@ local effectivePrbWorkflow = (prb) {
   on {
     pull_request {}
   }
-  jobs = (super.jobs |> withUploadTestResultXml |> withUploadTestResultHtml) {
+  jobs = (super.jobs |> withVerdict |> withUploadTestResultXml |> withUploadTestResultHtml) {
     ["upload-event-file"] {
       `runs-on` = "ubuntu-latest"
       steps {
@@ -474,6 +480,29 @@ local effectiveCodeQlWorkflow: Workflow = new {
           }
         }
       }
+    }
+  }
+}
+
+local withVerdict: Mixin<Workflow.Jobs> = (it) -> (it) {
+  ["verdict"] {
+    `runs-on` = "ubuntu-latest"
+    // allow any dependencies to either succeed or be skipped
+    `if` = "!cancelled() && !failure()"
+    needs =
+      prbRequiredJobs
+        // fallback: depend on any job that has no dependent jobs
+        ?? new Listing {
+          "check-pkl-github-actions"
+          for (jobName in it.keys) {
+            // when no job's `needs` contains `jobName`
+            when (!it.any((_, job) -> job.needs?.contains(jobName) ?? false)) {
+              jobName
+            }
+          }
+        }
+    steps {
+      new { run = "true" }
     }
   }
 }
@@ -634,7 +663,7 @@ hidden const isValid: (Workflow) -> Boolean = (workflow) ->
                   // the zizmor project has a great tool for identifying these: https://github.com/zizmorcore/zizmor/blob/main/support/codeql-injection-sinks.py
                   // and a few manually maintained entries: https://github.com/zizmorcore/zizmor/blob/cdc816b480a895144197fab903efc819810aca17/crates/zizmor/src/audit/template_injection.rs#L59-L74
                   List(
-                    "[job:\(job.key) step:\(stepIndex) field:run] Potential template injection, use expressions via `env` instead"
+                    "[job:\(job.key) step:\(stepIndex) field:run] Potential template injection, use expressions via `env` instead",
                   )
                 else
                   List()

--- a/packages/pkl.impl.ghactions/PklProject
+++ b/packages/pkl.impl.ghactions/PklProject
@@ -17,21 +17,21 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.7.1"
+  version = "1.8.0"
 }
 
 dependencies {
   ["com.github.actions"] {
-    uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.6.0"
+    uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.7.0"
   }
   ["com.github.dependabot"] {
     uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.4"
   }
   ["deepToTyped"] {
-    uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.1.1"
+    uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.0"
   }
   ["pkl.github.dependabotManagedActions"] {
-    uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.3"
+    uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.6"
   }
 }
 

--- a/packages/pkl.impl.ghactions/PklProject.deps.json
+++ b/packages/pkl.impl.ghactions/PklProject.deps.json
@@ -10,16 +10,16 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.3",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.6",
       "checksums": {
-        "sha256": "521feb6f5ff12075ebad0758799fe7ec2675d231a0e0f5456694c8d4822a8171"
+        "sha256": "85ad51d257bad4729f0b9edecade48fcad6f55bacd0fa36106782475e912919a"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.6.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.7.0",
       "checksums": {
-        "sha256": "10e27d63df4a4520d8a9375962406ca5ffe74f396bd3cb1c19b1f8358505010a"
+        "sha256": "e3461c3f8d00a6a657f9fa4f391afdab4a53a2e528862a4d8624e545cd3cb2b1"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {

--- a/packages/pkl.impl.ghactions/tests/examples.pkl-expected.pcf
+++ b/packages/pkl.impl.ghactions/tests/examples.pkl-expected.pcf
@@ -65,6 +65,14 @@ examples {
         - uses: actions/checkout@abc123 # v6
           with:
             persist-credentials: false
+      verdict:
+        if: '!cancelled() && !failure()'
+        needs:
+        - check-pkl-github-actions
+        - do-build
+        runs-on: ubuntu-latest
+        steps:
+        - run: 'true'
       upload-event-file:
         runs-on: ubuntu-latest
         steps:
@@ -258,6 +266,14 @@ examples {
         runs-on: ubuntu-latest
         steps:
         - run: echo hello
+      verdict:
+        if: '!cancelled() && !failure()'
+        needs:
+        - check-pkl-github-actions
+        - do-build
+        runs-on: ubuntu-latest
+        steps:
+        - run: 'true'
       upload-event-file:
         runs-on: ubuntu-latest
         steps:
@@ -540,6 +556,14 @@ examples {
             name: test-results-xml-do-build
             path: '**.xml'
             if-no-files-found: ignore
+      verdict:
+        if: '!cancelled() && !failure()'
+        needs:
+        - check-pkl-github-actions
+        - do-build
+        runs-on: ubuntu-latest
+        steps:
+        - run: 'true'
       upload-event-file:
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
By default, all jobs of the `prb` workflow that have no dependent jobs will be required.
The set of required job names may be overridden by setting `prbRequiredJobs` on the module.

Also:
* Upgrade deps
* Upgrade formatter grammar version to 2 as all consumers are now using Pkl >= 0.30.