### PR TITLE
[pkl.impl.ghactions] Enable inserting additional steps before CodeQL init

### DIFF
--- a/.github/PklProject.deps.json
+++ b/.github/PklProject.deps.json
@@ -10,7 +10,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.8.2",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.9.0",
       "path": "../packages/pkl.impl.ghactions"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
@@ -22,16 +22,16 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.9",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.10",
       "checksums": {
-        "sha256": "467b91559f31ad7401c78d3df9569b5ec7aa4e1b49209f9f22d02bd72971e0bd"
+        "sha256": "dee9179c4db6239cb56e6ad9981ea27a309585fc1370f861ba299e4f4c3c0d97"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.4",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.1.0",
       "checksums": {
-        "sha256": "c7391119f946d7761d0ca0cc358ed8fe2bdfc691411087ccac89637bd96fec4a"
+        "sha256": "a797691aa08f2b4a4431bb0954e751643d81136ca25c58a647ae5153125efe28"
       }
     }
   }

--- a/packages/pkl.impl.ghactions/PklCI.pkl
+++ b/packages/pkl.impl.ghactions/PklCI.pkl
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 module pkl.impl.ghactions.PklCI
 
+import "@com.github.actions/AbstractJob.pkl"
 import "@com.github.actions/actions/checkout/v6/Checkout.pkl"
 import "@com.github.actions/context.pkl"
 import "@com.github.actions/github/codeql-action/Config.pkl" as CodeQLConfig
@@ -212,6 +213,9 @@ class CodeQLScan {
 
   /// Custom configuration for scanning.
   config: CodeQLConfig?
+
+  /// Additional steps to run between checkout and CodeQL init.
+  preSteps: Listing<AbstractJob.Step>
 }
 
 class CodeQL {
@@ -457,6 +461,7 @@ local effectiveCodeQlWorkflow: Workflow = new {
         }
         steps {
           catalog.`actions/checkout@v6`
+          ...scan.preSteps
           (catalog.`github/codeql-action/init@v4`) {
             with {
               languages = scan.language

--- a/packages/pkl.impl.ghactions/PklProject
+++ b/packages/pkl.impl.ghactions/PklProject
@@ -17,7 +17,7 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.8.2"
+  version = "1.9.0"
 }
 
 dependencies {
@@ -25,13 +25,13 @@ dependencies {
     uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.9.0"
   }
   ["com.github.dependabot"] {
-    uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.4"
+    uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.1.0"
   }
   ["deepToTyped"] {
     uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.1"
   }
   ["pkl.github.dependabotManagedActions"] {
-    uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.9"
+    uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.10"
   }
 }
 

--- a/packages/pkl.impl.ghactions/PklProject.deps.json
+++ b/packages/pkl.impl.ghactions/PklProject.deps.json
@@ -10,9 +10,9 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.9",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.10",
       "checksums": {
-        "sha256": "467b91559f31ad7401c78d3df9569b5ec7aa4e1b49209f9f22d02bd72971e0bd"
+        "sha256": "dee9179c4db6239cb56e6ad9981ea27a309585fc1370f861ba299e4f4c3c0d97"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {
@@ -24,9 +24,9 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.4",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.1.0",
       "checksums": {
-        "sha256": "c7391119f946d7761d0ca0cc358ed8fe2bdfc691411087ccac89637bd96fec4a"
+        "sha256": "a797691aa08f2b4a4431bb0954e751643d81136ca25c58a647ae5153125efe28"
       }
     }
   }


### PR DESCRIPTION
This is needed in pkl-readers because CodeQL will use the runner's pre-installed Go 1.24 runtime by default if none is explicitly installed and building pkl-readers requires Go 1.26 minimum.

This release won't be immediately adopted in all repos, just pkl-readers.